### PR TITLE
Pass source of service to Deployment API; render templates properly (…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN apk --no-cache add make git gcc libtool musl-dev
 WORKDIR /
 COPY go.mod .
 COPY go.sum .
-RUN go mod download
+RUN go mod download && rm go.mod go.sum

--- a/runtime/kubernetes/client/kubernetes.go
+++ b/runtime/kubernetes/client/kubernetes.go
@@ -38,6 +38,8 @@ type Kubernetes interface {
 
 // DefaultService returns default micro kubernetes service definition
 func DefaultService(name, version string) *Service {
+	log.Debugf("kubernetes default service: name: %s, version: %s", name, version)
+
 	Labels := map[string]string{
 		"name":    name,
 		"version": version,
@@ -73,7 +75,9 @@ func DefaultService(name, version string) *Service {
 }
 
 // DefaultService returns default micro kubernetes deployment definition
-func DefaultDeployment(name, version string) *Deployment {
+func DefaultDeployment(name, version, source string) *Deployment {
+	log.Debugf("kubernetes default deployment: name: %s, version: %s, source: %s", name, version, source)
+
 	Labels := map[string]string{
 		"name":    name,
 		"version": version,
@@ -102,7 +106,12 @@ func DefaultDeployment(name, version string) *Deployment {
 		log.Debugf("Runtime could not parse build: %v", err)
 	}
 
-	// TODO: change the image name here
+	// enable go modules by default
+	env := EnvVar{
+		Name:  "GO111MODULE",
+		Value: "on",
+	}
+
 	Spec := &DeploymentSpec{
 		Replicas: 1,
 		Selector: &LabelSelector{
@@ -114,8 +123,8 @@ func DefaultDeployment(name, version string) *Deployment {
 				Containers: []Container{{
 					Name:    name,
 					Image:   DefaultImage,
-					Env:     []EnvVar{},
-					Command: []string{"go", "run", "main.go"},
+					Env:     []EnvVar{env},
+					Command: []string{"go", "run", source},
 					Ports: []ContainerPort{{
 						Name:          name + "-port",
 						ContainerPort: 8080,

--- a/runtime/kubernetes/client/templates.go
+++ b/runtime/kubernetes/client/templates.go
@@ -1,8 +1,8 @@
 package client
 
 var templates = map[string]string{
-	"deployments": deploymentTmpl,
-	"services":    serviceTmpl,
+	"deployment": deploymentTmpl,
+	"service":    serviceTmpl,
 }
 
 var deploymentTmpl = `

--- a/runtime/kubernetes/client/utils.go
+++ b/runtime/kubernetes/client/utils.go
@@ -10,9 +10,9 @@ import (
 	"text/template"
 )
 
-// renderTemplateFile renders template file in path into writer w with supplied data
-func renderTemplate(text string, w io.Writer, data interface{}) error {
-	t := template.Must(template.New("kubernetes").Parse(text))
+// renderTemplateFile renders template for a given resource into writer w
+func renderTemplate(resource string, w io.Writer, data interface{}) error {
+	t := template.Must(template.New("kubernetes").Parse(templates[resource]))
 
 	if err := t.Execute(w, data); err != nil {
 		return err

--- a/runtime/kubernetes/client/utils_test.go
+++ b/runtime/kubernetes/client/utils_test.go
@@ -7,19 +7,20 @@ import (
 
 func TestTemplates(t *testing.T) {
 	name := "foo"
-	version := "1.2.3"
+	version := "123"
+	source := "github.com/foo/bar"
 
 	// Render default service
 	s := DefaultService(name, version)
 	bs := new(bytes.Buffer)
-	if err := renderTemplate(serviceTmpl, bs, s); err != nil {
+	if err := renderTemplate(templates["service"], bs, s); err != nil {
 		t.Errorf("Failed to render kubernetes service: %v", err)
 	}
 
 	// Render default deployment
-	d := DefaultDeployment(name, version)
+	d := DefaultDeployment(name, version, source)
 	bd := new(bytes.Buffer)
-	if err := renderTemplate(deploymentTmpl, bd, d); err != nil {
+	if err := renderTemplate(templates["deployment"], bd, d); err != nil {
 		t.Errorf("Failed to render kubernetes deployment: %v", err)
 	}
 }

--- a/runtime/kubernetes/service.go
+++ b/runtime/kubernetes/service.go
@@ -19,7 +19,7 @@ type service struct {
 
 func newService(s *runtime.Service, c runtime.CreateOptions) *service {
 	kservice := client.DefaultService(s.Name, s.Version)
-	kdeploy := client.DefaultDeployment(s.Name, s.Version)
+	kdeploy := client.DefaultDeployment(s.Name, s.Version, s.Source)
 
 	env := make([]client.EnvVar, 0, len(c.Env))
 	for _, evar := range c.Env {
@@ -27,15 +27,18 @@ func newService(s *runtime.Service, c runtime.CreateOptions) *service {
 		env = append(env, client.EnvVar{Name: evarPair[0], Value: evarPair[1]})
 	}
 
-	// TODO: should we append instead of overriding?
-	// if environment has been supplied update deployment
+	// if environment has been supplied update deployment default environment
 	if len(env) > 0 {
-		kdeploy.Spec.Template.PodSpec.Containers[0].Env = env
+		kdeploy.Spec.Template.PodSpec.Containers[0].Env = append(kdeploy.Spec.Template.PodSpec.Containers[0].Env, env...)
 	}
 
-	// if Command has been supplied override the default command
-	if len(c.Command) > 0 {
-		kdeploy.Spec.Template.PodSpec.Containers[0].Command = c.Command
+	// if Exec/Command has been supplied override the default command
+	if len(s.Exec) > 0 {
+		kdeploy.Spec.Template.PodSpec.Containers[0].Command = s.Exec
+	} else {
+		if len(c.Command) > 0 {
+			kdeploy.Spec.Template.PodSpec.Containers[0].Command = c.Command
+		}
 	}
 
 	return &service{


### PR DESCRIPTION
…#969)

* Pass source of service to Deployment API; render templates properly

* Enable Go modules by default. Honor runtime.Service.Exec

* Make sure you remove go.mod and go.sum